### PR TITLE
Remove unused `package.json` field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,6 @@
   "engines": {
     "node": ">=4"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
   "license": "MIT",
   "private": true,
   "repository": {


### PR DESCRIPTION
This is what happens when you blindly copypaste.