### PR TITLE
Don't wrap logged errors.

### DIFF
--- a/packages/easy-three/__tests__/init.test.js
+++ b/packages/easy-three/__tests__/init.test.js
@@ -87,7 +87,7 @@ describe('init', () => {
 
     it('logs a ConfigError if it there is one.', done => {
       const start = jest.fn();
-      pino.__setFatalFunc(({error}) => {
+      pino.__setFatalFunc(error => {
         expect(error.message).toEqual('Configuration could not be loaded.');
         expect(start).not.toHaveBeenCalled();
         done();
@@ -121,7 +121,7 @@ describe('init', () => {
 
     it('logs the error if "start" throws.', done => {
       const message = 'Some message.';
-      pino.__setFatalFunc(({error}) => {
+      pino.__setFatalFunc(error => {
         expect(error.message).toEqual(message);
         done();
       });
@@ -132,7 +132,7 @@ describe('init', () => {
 
     it('logs the error if "start" rejects.', done => {
       const message = 'Some message.';
-      pino.__setFatalFunc(({error}) => {
+      pino.__setFatalFunc(error => {
         expect(error.message).toEqual(message);
         done();
       });
@@ -171,7 +171,7 @@ describe('init', () => {
 
     it('logs the error if "shutdown" passes one.', done => {
       const message = 'Some message.';
-      pino.__setFatalFunc(({error}) => {
+      pino.__setFatalFunc(error => {
         expect(error.message).toEqual(message);
         done();
       });
@@ -184,7 +184,7 @@ describe('init', () => {
       const shutdown = () => {
         throw new Error(message);
       };
-      pino.__setErrorFunc(({error}) => {
+      pino.__setErrorFunc(error => {
         expect(error.message).toEqual(message);
         done();
       });
@@ -197,7 +197,7 @@ describe('init', () => {
       const shutdown = async () => {
         throw new Error(message);
       };
-      pino.__setErrorFunc(({error}) => {
+      pino.__setErrorFunc(error => {
         expect(error.message).toEqual(message);
         done();
       });

--- a/packages/easy-three/src/init.js
+++ b/packages/easy-three/src/init.js
@@ -31,7 +31,7 @@ export default function init<CMap: ConfigMap>(
     logger.trace('The logger has been initialized.');
     if (error) {
       return logger.fatal(
-        {error},
+        error,
         'Configuration could not be loaded.  Application will not start.',
       );
     }
@@ -47,14 +47,14 @@ export default function init<CMap: ConfigMap>(
         }
         death((signal, err) => {
           if (err) {
-            logger.fatal({error: err}, 'Aborting due to fatal error.');
+            logger.fatal(err, 'Aborting due to fatal error.');
           }
           logger.info({signal}, 'Shutting down.');
           pTry(() => shutdown(signal, err)).then(
             () => logger.info('The application has been gracefully shut down.'),
             shutdownError =>
               logger.error(
-                {error: shutdownError},
+                shutdownError,
                 'An error was encountered while attempting to shut down.',
               ),
           );
@@ -62,7 +62,7 @@ export default function init<CMap: ConfigMap>(
       },
       startError =>
         logger.fatal(
-          {error: startError},
+          startError,
           'An error was encountered while attempting to initialize.',
         ),
     );


### PR DESCRIPTION
`pino` can't log them properly if they're wrapped.