### PR TITLE
Remove `pretty` support from logger.

### DIFF
--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -16,7 +16,8 @@
     "@babel/core": "^7.0.0-beta.46",
     "@babel/node": "^7.0.0-beta.46",
     "@babel/preset-env": "^7.0.0-beta.46",
-    "@babel/preset-flow": "^7.0.0-beta.46"
+    "@babel/preset-flow": "^7.0.0-beta.46",
+    "pino-pretty": "^1.0.1"
   },
   "engines": {
     "node": ">=6"
@@ -29,7 +30,7 @@
     "url": "https://github.com/wtgtybhertgeghgtwtg/easy-three"
   },
   "scripts": {
-    "start": "babel-node src"
+    "start": "babel-node src | pino-pretty"
   },
   "version": "0.0.0"
 }

--- a/examples/fastify/sample-env
+++ b/examples/fastify/sample-env
@@ -1,6 +1,4 @@
 # Set a log level to use, instead of the default "info".
 LOG_LEVEL=trace
-# Make the logs formatted.
-LOG_PRETTY=true
 # Use port 4000.
 PORT=4000

--- a/packages/easy-three/__tests__/init.test.js
+++ b/packages/easy-three/__tests__/init.test.js
@@ -37,35 +37,13 @@ describe('init', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       delete process.env.LOG_LEVEL;
-      delete process.env.LOG_PRETTY;
-    });
-
-    // Terrible test name.
-    it('defaults to non-pretty "info".', async () => {
-      await init({}, () => () => {});
-      expect(pino).toHaveBeenCalledWith({
-        level: 'info',
-        prettyPrint: false,
-      });
     });
 
     it('passes "LOG_LEVEL" as the log level.', async () => {
       const logLevel = 'trace';
       process.env.LOG_LEVEL = logLevel;
       await init({}, () => () => {});
-      expect(pino).toHaveBeenCalledWith({
-        level: logLevel,
-        prettyPrint: false,
-      });
-    });
-
-    it('is pretty if "LOG_PRETTY" equals true.', async () => {
-      process.env.LOG_PRETTY = 'true';
-      await init({}, () => () => {});
-      expect(pino).toHaveBeenCalledWith({
-        level: 'info',
-        prettyPrint: true,
-      });
+      expect(pino).toHaveBeenCalledWith({level: logLevel});
     });
   });
 

--- a/packages/easy-three/src/baseConfig.js
+++ b/packages/easy-three/src/baseConfig.js
@@ -1,6 +1,5 @@
 export default {
   logger: {
     level: 'LOG_LEVEL',
-    pretty: 'LOG_PRETTY',
   },
 };

--- a/packages/easy-three/src/init.js
+++ b/packages/easy-three/src/init.js
@@ -25,10 +25,7 @@ export default function init<CMap: ConfigMap>(
   assert(typeof start === 'function', '"start" must be a function.');
   return loadConfig(assignDeep(baseConfig, configMap)).then(
     config => {
-      const logger = pino({
-        level: config.logger.level || 'info',
-        prettyPrint: config.logger.pretty === 'true',
-      });
+      const logger = pino({level: config.logger.level || 'info'});
       logger.trace('The logger has been initialized.');
       logger.debug('Configuration has been loaded.');
       return pTry(() => start(config, logger)).then(


### PR DESCRIPTION
`pino` won't have it as a dependency in the next version.  It also is the only reason I feel safe doing #34.